### PR TITLE
Refactor/yusa liu/tidy up the goroutine lifecycle arrangement

### DIFF
--- a/quorum-election/cmd/main.go
+++ b/quorum-election/cmd/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/Anthya1104/quorum-election-cli/internal/cobra"
 	"github.com/Anthya1104/quorum-election-cli/internal/config"
@@ -15,6 +18,7 @@ import (
 )
 
 func main() {
+
 	if err := logger.InitLogger(config.LogLevelInfo); err != nil {
 		logrus.Fatalf("Error initializing Logger : %v", err)
 	}
@@ -24,7 +28,68 @@ func main() {
 		os.Exit(1)
 	}
 
+	// goroutine for main function flow controlling
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	// graceful shutdown
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		select {
+		case sig := <-sigChan:
+			logrus.Infof("Received signal %v. Initiating graceful shutdown...", sig)
+			cancel()
+		case <-ctx.Done():
+			logrus.Debug("Signal listener goroutine received context done.")
+			return
+		}
+	}()
+
+	// tracking runQuorumCLI (in main.go layer)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runQuorumCLI(ctx, cancel)
+	}()
+
+	logrus.Info("Main function waiting for all top-level goroutines to finish...")
+	wg.Wait()
+	logrus.Info("All top-level goroutines finished. Exiting application.")
+	os.Exit(0)
+}
+
+func readInputLoop(ctx context.Context, inputChan chan<- string) {
 	reader := bufio.NewReader(os.Stdin)
+	for {
+		select {
+		case <-ctx.Done():
+			logrus.Debug("Input reader goroutine received context done, stopping.")
+			return
+		default:
+			input, err := reader.ReadString('\n')
+			if err != nil { // ctrl+C or other error
+				logrus.Debugf("Error reading input or EOF: %v. Stopping input reader.", err)
+				return
+			}
+			select {
+			case inputChan <- strings.TrimSpace(input):
+			case <-ctx.Done():
+				logrus.Debug("Input reader goroutine context done while sending input.")
+				return
+			}
+		}
+	}
+}
+
+// manage the CLI tool by context created in main.go
+func runQuorumCLI(ctx context.Context, cancel context.CancelFunc) {
+	// channel to read input
+	inputChan := make(chan string)
+	go readInputLoop(ctx, inputChan)
 
 	var quorum *core.Quorum
 	var members = cobra.GetMembers()
@@ -33,8 +98,19 @@ func main() {
 
 restartLoop:
 	for {
-		var wg sync.WaitGroup
-		quorum = core.NewQuorum(members, realTimer, core.NewNoOpNotifier(), &wg)
+		select {
+		case <-ctx.Done():
+			logrus.Info("Graceful shutdown initiated. Exiting restart loop.")
+			if quorum != nil {
+				quorum.Stop()
+			}
+			return
+		default:
+			// continue the game
+		}
+
+		// quorum instance managed by internal context -> only notify the main layer when all goroutines done
+		quorum = core.NewQuorum(members, realTimer, core.NewNoOpNotifier())
 		quorum.Start()
 
 	mainLoop:
@@ -43,31 +119,50 @@ restartLoop:
 			case <-quorum.Done():
 				logrus.Info("Quorum ended. Returning to main loop.")
 				break mainLoop
-			default:
-				input, _ := reader.ReadString('\n')
-				input = strings.TrimSpace(input)
 
+			case <-ctx.Done():
+				logrus.Info("Graceful shutdown initiated. Stopping quorum and exiting CLI.")
+				if quorum != nil {
+					quorum.Stop()
+				}
+				return
+
+			case input := <-inputChan:
 				switch {
 				case input == "exit":
-					logrus.Info("Exiting CLI...")
-					quorum.Stop()
-					return
+					logrus.Info("CLI Command: Exiting CLI...")
+					cancel()
+
 				case input == "restart":
-					logrus.Info("Restarting quorum...")
-					quorum.Stop()
+					logrus.Info("CLI Command: Restarting quorum...")
+					if quorum != nil {
+						quorum.Stop() // waited until the quorum internal flow all done
+					}
 					continue restartLoop
+
 				case strings.HasPrefix(input, "kill "):
 					parts := strings.Split(input, " ")
 					if len(parts) == 2 {
 						id, err := strconv.Atoi(parts[1])
 						if err == nil {
-							quorum.KillMember(id)
+							if quorum != nil {
+								quorum.KillMember(id)
+							} else {
+								logrus.Warn("Quorum not active to kill member.")
+							}
+						} else {
+							logrus.Errorf("Invalid member ID: %s", parts[1])
 						}
+					} else {
+						logrus.Error("Usage: kill <member_id>")
 					}
 				default:
 					logrus.Error("Unknown command")
 				}
 			}
+		}
+		if quorum != nil {
+			quorum.Stop()
 		}
 	}
 }

--- a/quorum-election/cmd/main.go
+++ b/quorum-election/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/Anthya1104/quorum-election-cli/internal/cobra"
 	"github.com/Anthya1104/quorum-election-cli/internal/config"
@@ -32,7 +33,8 @@ func main() {
 
 restartLoop:
 	for {
-		quorum = core.NewQuorum(members, realTimer, core.NewNoOpNotifier())
+		var wg sync.WaitGroup
+		quorum = core.NewQuorum(members, realTimer, core.NewNoOpNotifier(), &wg)
 		quorum.Start()
 
 	mainLoop:

--- a/quorum-election/internal/core/member.go
+++ b/quorum-election/internal/core/member.go
@@ -47,9 +47,10 @@ type Member struct {
 	Election  ElectionStrategy
 	timer     Timer
 	networker Networker
+	wg        *sync.WaitGroup
 }
 
-func NewMember(ctx context.Context, id int, strategy ElectionStrategy, timer Timer, networker Networker, initialPeers []int) *Member {
+func NewMember(ctx context.Context, id int, strategy ElectionStrategy, timer Timer, networker Networker, initialPeers []int, wg *sync.WaitGroup) *Member {
 	ctx, cancel := context.WithCancel(ctx)
 	logrus.Infof("Member %v: Hi", id)
 
@@ -63,6 +64,7 @@ func NewMember(ctx context.Context, id int, strategy ElectionStrategy, timer Tim
 		Election:  strategy,
 		timer:     timer,
 		networker: networker,
+		wg:        wg,
 	}
 
 	// init lastSeen to prevent suspecting others immediately
@@ -76,6 +78,8 @@ func NewMember(ctx context.Context, id int, strategy ElectionStrategy, timer Tim
 }
 
 func (m *Member) Run(q *Quorum) {
+	defer m.wg.Done()
+
 	go m.sendHeartbeats()
 	go m.monitorHeartbeats(q)
 

--- a/quorum-election/internal/core/member.go
+++ b/quorum-election/internal/core/member.go
@@ -51,7 +51,7 @@ type Member struct {
 }
 
 func NewMember(ctx context.Context, id int, strategy ElectionStrategy, timer Timer, networker Networker, initialPeers []int, wg *sync.WaitGroup) *Member {
-	ctx, cancel := context.WithCancel(ctx)
+	memberCtx, cancel := context.WithCancel(ctx)
 	logrus.Infof("Member %v: Hi", id)
 
 	m := &Member{
@@ -59,7 +59,7 @@ func NewMember(ctx context.Context, id int, strategy ElectionStrategy, timer Tim
 		Alive:     true,
 		Inbox:     make(chan Message, 10),
 		lastSeen:  make(map[int]time.Time),
-		ctx:       ctx,
+		ctx:       memberCtx,
 		cancel:    cancel,
 		Election:  strategy,
 		timer:     timer,


### PR DESCRIPTION
feat:
 - added graceful shutdown mechanism
refactor:
- encapsulate the Quorum context as internal ctx to seperate the wg management from main()
- extracted run cli flow as runQuorumCLI function